### PR TITLE
Update game-of-thrones.json

### DIFF
--- a/src/entertainment/game-of-thrones.json
+++ b/src/entertainment/game-of-thrones.json
@@ -188,7 +188,7 @@
       "people": [
         {
           "name": "Margaery (Tyrell) Baratheon",
-          "description": "Widow of Renly Baratheon - Sister of Loras Tyrell - Granddaughter of Olenna Tyrell",
+          "description": "Wife of Renly Baratheon - Sister of Loras Tyrell - Granddaughter of Olenna Tyrell",
           "imageSuffix": "margaery-tyrell",
           "wikiSuffix": "Margaery_Tyrell"
         },


### PR DESCRIPTION
If you want to keep this spoiler free, Margaery is Renly's wife at the moment she is introduced, not his widow...
