### PR TITLE
Corrected unix json 'Shortcut' section

### DIFF
--- a/src/programming/unix-linux.json
+++ b/src/programming/unix-linux.json
@@ -371,7 +371,7 @@
           "description": "move cursor to beginning of line"
         },
         {
-          "command": "ctrl+f",
+          "command": "ctrl+e",
           "description": "move cursor to end of line"
         },
         {


### PR DESCRIPTION
ctrl+f moves cursor one step forward, ctrl+e moves cursor to the end of line
