### PR TITLE
correct command for cursor movement to end of line

### DIFF
--- a/src/programming/unix-linux.json
+++ b/src/programming/unix-linux.json
@@ -371,7 +371,7 @@
           "description": "move cursor to beginning of line"
         },
         {
-          "command": "ctrl+f",
+          "command": "ctrl+e",
           "description": "move cursor to end of line"
         },
         {


### PR DESCRIPTION
Ctrl+e moves to the *e*nd of the line; ctrl+f moves *f*orward by 1 character (this is why alt+f moves forward by 1 word)